### PR TITLE
Clean up path handling

### DIFF
--- a/ase/ace/ace.py
+++ b/ase/ace/ace.py
@@ -117,9 +117,9 @@ class ACECalculator(Calculator):
     if initcmd != None and jsonpath == None and standard_eval == False: 
       cmd = calcid + " = " + initcmd
     elif jsonpath != None and initcmd == None and standard_eval == False: 
-      cmd = calcid + " = read_dict( load_dict(\"" + jsonpath + "\")[\"IP\"])"
+      cmd = calcid + " = read_dict( load_dict(\"" + str(jsonpath) + "\")[\"IP\"])"
     elif jsonpath != None and initcmd == None and standard_eval == True: 
-      cmd = calcid + " = read_dict( load_dict(\"" + jsonpath + "\")[\"IP\"]); "
+      cmd = calcid + " = read_dict( load_dict(\"" + str(jsonpath) + "\")[\"IP\"]); "
       cmd += calcid + "=  JuLIP.MLIPs.SumIP({0}.components[1], {0}.components[2], standardevaluator({0}.components[3]))".format(calcid)
     else:
       raise ValueError("exactly one of jsonpath and initcmd must be provided")

--- a/ase/test_ase_calc.py
+++ b/ase/test_ase_calc.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 from ase.io import read
 import ace
 
-at = read("../assets/ch_test2.xyz")
+at = read(Path(__file__).parent / "../assets/ch_test2.xyz")
 
-cace_calc = ace.ACECalculator(jsonpath="../assets/CH_ace_test.json", ACE_version=1)
+cace_calc = ace.ACECalculator(jsonpath=Path(__file__).parent / "../assets/CH_ace_test.json", ACE_version=1)
 
 at.set_calculator(cace_calc)
 


### PR DESCRIPTION
Allow ace.py to get jsonpath as a pathlib.Path, and make test_ase_calc.py calculate paths to xyz and ACE.json file relative to its own path